### PR TITLE
Add release headings even for bumps with no git logs (fixes #26)

### DIFF
--- a/lib/ops/changelog.js
+++ b/lib/ops/changelog.js
@@ -12,19 +12,23 @@ async function changelog (version, logs) {
     throw new Error(`Invalid or missing version argument ${version}`);
   }
 
-  if (isNotGiven(logs) || isNotArray(logs) || logs.length === 0) {
+  if (isNotGiven(logs) || isNotArray(logs)) {
     throw new Error(`Invalid or missing logs argument ${logs}`);
   }
 
-  logs = logs.map((log) => `* ${log}`).join('\n');
-
   version = semver.clean(version);
 
-  let content = `v${version} - ${moment().format('MMMM D, YYYY')}\n\n${logs}`;
+  let content = `v${version} - ${moment().format('MMMM D, YYYY')}\n`;
+
+  logs = logs.map((log) => `* ${log}`).join('\n');
+
+  if (logs !== '') {
+    content += `\n${logs}\n`;
+  }
 
   try {
     const oldContent = await readFile('CHANGELOG.md', 'utf8');
-    content += `\n\n${oldContent}`;
+    content += `\n${oldContent}`;
   } catch (error) {
     // Ignore exception only if CHANGELOG.md file not exists
     if (error.code !== 'ENOENT') {


### PR DESCRIPTION
Even for releases with no commits (git logs) between the last tag and the HEAD
we should add at least an empty release head like so:

```markdown
v1.9.1 - July 15, 2021

v1.9.0 - July 11, 2021

 * log1
 * log2
 * ...
...
```

Fixes #26